### PR TITLE
Freesurfer-statistics instruction

### DIFF
--- a/docs/tutorial/t1w-preprocessing.md
+++ b/docs/tutorial/t1w-preprocessing.md
@@ -112,8 +112,8 @@ Once you're happy with the surfaces, you can move computing statistics!
 ### Freesurfer Brain Parcellation - Statistics.
 
 1. On the 'Process' tab, click 'Submit App' to submit a new application.
-    * In the search bar, type 'Freesurfer.'
-    * Click the app card.
+    * In the search bar, type 'Freesurfer'.
+    * Click the "Freesurfer Statistics" app card.
 1. On the 'Submit App' page, select the following:
     * For input, select the Freesurfer output generated in Step 3 by clicking the drop-down menu and finding the appropriate dataset (look for the datatag 'freesurfer'.
     * For parcellation, please choose the parcellation of your choice. For this tutorial, we will use the 'aparc.a2009s'. To choose this, select the 'aparc.a2009s' option from the drop-down menu.


### PR DESCRIPTION
I was working through the tutorials and noticed some potential edits to the tutorial. 

Changed app card name in freesurfer brain parcellation - statistics section. 

Also I can't seem to visualize all the surface and volumes in `Freesurfer Brain Parcellation - Generation` section, not sure how to fix it or what the appropriate instruction should be. 