### PR TITLE
reason: update cli install for npm

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -13,8 +13,16 @@ Brainlife CLI is distributed through [npm](https://www.npmjs.com/){target=_blank
 On ubuntu/debian machines, you can run the following command to install nodejs 14 (current LTS).
 
 ```
-curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+sudo apt update
+sudo apt upgrade
+sudo apt install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt update
 sudo apt-get install -y nodejs
+sudo npm install -g npm@10.2.4
 ```
 
 !!! Installation For "Mac OSX users"


### PR DESCRIPTION
installation instructions for installation of nodejs are out of date.

these are the most up-to-date instructions i could find.

tested on an Ubuntu 22.04 machine and it worked just fine.